### PR TITLE
Small code improvement. Introducing C++17 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.3)
 project(Hsm)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 
 set(SOURCE_FILES
     hsm.h

--- a/hsm.h
+++ b/hsm.h
@@ -19,8 +19,8 @@
 
 template <typename _Host>
 struct TopState {
-    typedef _Host Host;
-    typedef void Base;
+    using Host = _Host;
+    using Base = void;
     virtual void handler(Host&) const = 0;
     virtual unsigned getId() const = 0;
 };
@@ -30,8 +30,8 @@ struct CompState;
 
 template <typename _Host, unsigned id, typename _Base = CompState<_Host, 0, TopState<_Host> > >
 struct CompState : _Base {
-    typedef _Base Base;
-    typedef CompState<_Host, id, Base> This;
+    using Base = _Base;
+    using This = CompState<_Host, id, Base>;
     template <typename X>
     void handle(_Host& h, const X& x) const {
         Base::handle(h, x);
@@ -43,8 +43,8 @@ struct CompState : _Base {
 
 template <typename _Host>
 struct CompState<_Host, 0, TopState<_Host> > : TopState<_Host> {
-    typedef TopState<_Host> Base;
-    typedef CompState<_Host, 0, Base> This;
+    using Base = TopState<_Host>;
+    using This = CompState<_Host, 0, Base>;
     template <typename X>
     void handle(_Host&, const X&) const {}
     static void init(_Host&);  // no implementation
@@ -54,9 +54,9 @@ struct CompState<_Host, 0, TopState<_Host> > : TopState<_Host> {
 
 template <typename _Host, unsigned id, typename _Base = CompState<_Host, 0, TopState<_Host> > >
 struct LeafState : _Base {
-    typedef _Host Host;
-    typedef _Base Base;
-    typedef LeafState<Host, id, Base> This;
+    using Host = _Host;
+    using Base = _Base;
+    using This = LeafState<Host, id, Base>;
     template <typename X>
     void handle(Host& h, const X& x) const {
         Base::handle(h, x);

--- a/hsm.h
+++ b/hsm.h
@@ -35,7 +35,7 @@ struct CompState : _Base {
     using Base = _Base;
     using This = CompState<_Host, id, Base>;
     template <typename X>
-    void handle(_Host& h, const X& x) const {
+    static void handle(_Host& h, const X& x) {
         Base::handle(h, x);
     }
     static void init(_Host&);  // no implementation
@@ -48,23 +48,23 @@ struct CompState<_Host, 0, TopState<_Host> > : TopState<_Host> {
     using Base = TopState<_Host>;
     using This = CompState<_Host, 0, Base>;
     template <typename X>
-    void handle(_Host&, const X&) const {}
+    static void handle(_Host&, const X&) {}
     static void init(_Host&);  // no implementation
     static void entry(_Host&) {}
     static void exit(_Host&) {}
 };
 
 template <typename _Host, unsigned id, typename _Base = CompState<_Host, 0, TopState<_Host> > >
-struct LeafState : _Base {
+struct LeafState final : _Base {
     using Host = _Host;
     using Base = _Base;
     using This = LeafState<Host, id, Base>;
     template <typename X>
-    void handle(Host& h, const X& x) const {
+    static void handle(Host& h, const X& x) {
         Base::handle(h, x);
     }
-    virtual void handler(Host& hsm) const override { handle(hsm, *this); }
-    virtual unsigned getId() const override { return id; }
+    void handler(Host& hsm) const override { handle(hsm, obj); }
+    unsigned getId() const override { return id; }
     static void init(Host& hsm) { hsm.next(obj); }  // don't specialize this
     static void entry(Host&) {}
     static void exit(Host&) {}

--- a/hsm.h
+++ b/hsm.h
@@ -63,20 +63,15 @@ struct LeafState : _Base {
     void handle(Host& h, const X& x) const {
         Base::handle(h, x);
     }
-    virtual void handler(Host& hsm) const { handle(hsm, *this); }
-    virtual unsigned getId() const { return id; }
+    virtual void handler(Host& hsm) const override { handle(hsm, *this); }
+    virtual unsigned getId() const override { return id; }
     static void init(Host& hsm) { hsm.next(obj); }  // don't specialize this
     static void entry(Host&) {}
     static void exit(Host&) {}
-    static const LeafState obj;  // only the leaf states have instances
+    static inline const LeafState obj{};  // only the leaf states have instances
 };
 
-template <typename _Host, unsigned id, typename _Base>
-const LeafState<_Host, id, _Base> LeafState<_Host, id, _Base>::obj;
-
-
 // Transition Object
-
 template <typename _Current, typename _Source, typename _Target>
 struct Tran {
     using Host = typename _Current::Host;

--- a/hsm.h
+++ b/hsm.h
@@ -25,6 +25,8 @@ struct TopState {
     using Base = void;
     virtual void handler(Host&) const = 0;
     virtual unsigned getId() const = 0;
+    protected: // To forbit explicit instance creation.
+    TopState() = default;
 };
 
 template <typename _Host, unsigned id, typename _Base>
@@ -41,6 +43,8 @@ struct CompState : _Base {
     static void init(_Host&);  // no implementation
     static void entry(_Host&) {}
     static void exit(_Host&) {}
+    protected:
+    CompState() = default;
 };
 
 template <typename _Host>
@@ -52,6 +56,8 @@ struct CompState<_Host, 0, TopState<_Host> > : TopState<_Host> {
     static void init(_Host&);  // no implementation
     static void entry(_Host&) {}
     static void exit(_Host&) {}
+    protected:
+    CompState() = default;
 };
 
 template <typename _Host, unsigned id, typename _Base = CompState<_Host, 0, TopState<_Host> > >
@@ -69,6 +75,8 @@ struct LeafState final : _Base {
     static void entry(Host&) {}
     static void exit(Host&) {}
     static inline const LeafState obj{};  // only the leaf states have instances
+    protected:
+    LeafState() = default;
 };
 
 // Transition Object
@@ -97,11 +105,6 @@ struct Tran {
         entryStop = eS_C || (eS_CB && (!eC_S || eT_C))
     };
 
-    // We use overloading to stop recursion.
-    // The more natural template specialization
-    // method would require to specialize the inner
-    // template without specializing the outer one,
-    // which is forbidden.
     template <bool ExitStop>
     static void exitActions(Host &hsm) {
         if constexpr (!ExitStop) {

--- a/main.cpp
+++ b/main.cpp
@@ -46,13 +46,13 @@
 
 class TestHSM;
 
-typedef CompState<TestHSM, 0> Top;
-typedef CompState<TestHSM, 1, Top> S;
-typedef CompState<TestHSM, 2, S> S1;
-typedef LeafState<TestHSM, 3, S1> S11;
-typedef CompState<TestHSM, 4, S> S2;
-typedef CompState<TestHSM, 5, S2> S21;
-typedef LeafState<TestHSM, 6, S21> S211;
+using Top  = CompState<TestHSM, 0>;
+using S    = CompState<TestHSM, 1, Top>;
+using S1   = CompState<TestHSM, 2, S>;
+using S11  = LeafState<TestHSM, 3, S1>;
+using S2   = CompState<TestHSM, 4, S>;
+using S21  = CompState<TestHSM, 5, S2>;
+using S211 = LeafState<TestHSM, 6, S21>;
 
 enum Signal { A_SIG, B_SIG, C_SIG, D_SIG, E_SIG, F_SIG, G_SIG, H_SIG, I_SIG };
 
@@ -133,7 +133,7 @@ int main(int, char**) {
 
 template <>
 template <typename X>
-inline void S::handle(TestHSM& h, const X& x) const {
+inline void S::handle(TestHSM& h, const X& x) {
     switch (h.getSig()) {
         case E_SIG: {
             fprintf(stderr, "S-E;");
@@ -156,7 +156,7 @@ inline void S::handle(TestHSM& h, const X& x) const {
 
 template <>
 template <typename X>
-inline void S1::handle(TestHSM& h, const X& x) const {
+inline void S1::handle(TestHSM& h, const X& x) {
     switch (h.getSig()) {
         case A_SIG: {
             fprintf(stderr, "S1-A;");
@@ -198,7 +198,7 @@ inline void S1::handle(TestHSM& h, const X& x) const {
 
 template <>
 template <typename X>
-inline void S11::handle(TestHSM& h, const X& x) const {
+inline void S11::handle(TestHSM& h, const X& x) {
     switch (h.getSig()) {
         case D_SIG: {
             if (h.foo()) {
@@ -227,7 +227,7 @@ inline void S11::handle(TestHSM& h, const X& x) const {
 
 template <>
 template <typename X>
-inline void S2::handle(TestHSM& h, const X& x) const {
+inline void S2::handle(TestHSM& h, const X& x) {
     switch (h.getSig()) {
         case C_SIG: {
             fprintf(stderr, "S2-C;");
@@ -255,7 +255,7 @@ inline void S2::handle(TestHSM& h, const X& x) const {
 
 template <>
 template <typename X>
-inline void S21::handle(TestHSM& h, const X& x) const {
+inline void S21::handle(TestHSM& h, const X& x) {
     switch (h.getSig()) {
         case A_SIG: {
             fprintf(stderr, "S21-A;");
@@ -280,7 +280,7 @@ inline void S21::handle(TestHSM& h, const X& x) const {
 
 template <>
 template <typename X>
-inline void S211::handle(TestHSM& h, const X& x) const {
+inline void S211::handle(TestHSM& h, const X& x) {
     switch (h.getSig()) {
         case D_SIG: {
             fprintf(stderr, "s211-D;");

--- a/main.cpp
+++ b/main.cpp
@@ -46,13 +46,19 @@
 
 class TestHSM;
 
-using Top  = CompState<TestHSM, 0>;
-using S    = CompState<TestHSM, 1, Top>;
-using S1   = CompState<TestHSM, 2, S>;
-using S11  = LeafState<TestHSM, 3, S1>;
-using S2   = CompState<TestHSM, 4, S>;
-using S21  = CompState<TestHSM, 5, S2>;
-using S211 = LeafState<TestHSM, 6, S21>;
+template <int Id = 0, typename _Base = TopState<TestHSM>>
+using HSMComp = CompState<TestHSM, Id, _Base>;
+
+template <int Id, typename _Base>
+using HSMLeaf = LeafState<TestHSM, Id, _Base>;
+
+using Top  = HSMComp<>;
+using S    = HSMComp<1, Top>;
+using S1   = HSMComp<2, S>;
+using S11  = HSMLeaf<3, S1>;
+using S2   = HSMComp<4, S>;
+using S21  = HSMComp<5, S2>;
+using S211 = HSMLeaf<6, S21>;
 
 enum Signal { A_SIG, B_SIG, C_SIG, D_SIG, E_SIG, F_SIG, G_SIG, H_SIG, I_SIG };
 


### PR DESCRIPTION
Changed code layout, introduced C++17 standard, removed some redundant code.
Did not touch design as huge changes could lead to complete redesign. Did not touch some nit-picks as using `enum class`, proper getters and setters, encapsulation, etc.